### PR TITLE
feat: 자동 구성 빈 등록 (ImportSelector 클래스 이용.version)

### DIFF
--- a/HelloBoot/src/main/java/tobyspring/config/EnableMyAutoConfiguration.java
+++ b/HelloBoot/src/main/java/tobyspring/config/EnableMyAutoConfiguration.java
@@ -1,8 +1,6 @@
 package tobyspring.config;
 
 import org.springframework.context.annotation.Import;
-import tobyspring.config.autoconfig.DispatcherServletConfig;
-import tobyspring.config.autoconfig.TomcatWebServerConfig;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -11,6 +9,6 @@ import java.lang.annotation.Target;
 
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
-@Import({DispatcherServletConfig.class, TomcatWebServerConfig.class})   // @Import 이용하여 스캔 영역에 없는 클래스를 스캔 및 구성 정보로 추가되도록 함.
+@Import(MyAutoConfigImportSelector.class)   //  동적으로 필요한 설정 정보 import하는 ImportSelector만 임포트
 public @interface EnableMyAutoConfiguration {
 }

--- a/HelloBoot/src/main/java/tobyspring/config/MyAutoConfigImportSelector.java
+++ b/HelloBoot/src/main/java/tobyspring/config/MyAutoConfigImportSelector.java
@@ -1,0 +1,14 @@
+package tobyspring.config;
+
+import org.springframework.context.annotation.DeferredImportSelector;
+import org.springframework.core.type.AnnotationMetadata;
+
+public class MyAutoConfigImportSelector implements DeferredImportSelector {
+    @Override
+    public String[] selectImports(AnnotationMetadata importingClassMetadata) {
+        return new String[] {
+                "tobyspring.config.autoconfig.DispatcherServletConfig",
+                "tobyspring.config.autoconfig.TomcatWebServerConfig"
+        };
+    }
+}


### PR DESCRIPTION
Config 파일(`EnableMyAutoConfiguration`)에서 필요한 설정 정보를 동적으로 임포트하는 방법
- ImportSelector로 분리(`DeferredImportSelector` 구현)
  - `selectImports` 메서드에서 필요한 설정 정보를 동적으로 설정하여 `String[]`으로 반환하도록 작성함.