### PR TITLE
feat: stubbing (Mock 객체에 대한 행위 지정) 추가

### DIFF
--- a/cafekiosk/src/main/java/sample/cafekiosk/spring/client/mail/MailSendClient.java
+++ b/cafekiosk/src/main/java/sample/cafekiosk/spring/client/mail/MailSendClient.java
@@ -12,7 +12,6 @@ public class MailSendClient {
 
     public boolean sendEmail(String fromEmail, String toEmail, String title, String content) {
         log.info("메일 전송");
-
-        return true;
+        throw new IllegalArgumentException("메일 전송");
     }
 }

--- a/cafekiosk/src/main/java/sample/cafekiosk/spring/domain/order/OrderStatisticsService.java
+++ b/cafekiosk/src/main/java/sample/cafekiosk/spring/domain/order/OrderStatisticsService.java
@@ -10,8 +10,12 @@ import java.util.List;
 
 /**
  * 하루의 총 매출 통계를 내어 메일 발송 요청하는 Service.
+ * !알아둘 점!
+ * 네트워크를 타거나 실제로는 트랜잭션에 참여하지 않아도 되면서 오랜 시간이 소요되는 서비스 (ex. 메일 전송)에서는
+ * 트랜잭션을 소유하고 있지 않도록 @Transactional을 걸지 않는 것이 좋음.
+ * 아래 메서드 내에 조회 메서드는 Repository 단에서 트랜잭션을 걸도록 되어 있음.
  */
-@Transactional(readOnly = true)
+//@Transactional(readOnly = true)
 @RequiredArgsConstructor
 @Service
 public class OrderStatisticsService {

--- a/cafekiosk/src/test/java/sample/cafekiosk/spring/domain/order/OrderStatisticsServiceTest.java
+++ b/cafekiosk/src/test/java/sample/cafekiosk/spring/domain/order/OrderStatisticsServiceTest.java
@@ -5,6 +5,9 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.transaction.annotation.Transactional;
+import sample.cafekiosk.spring.client.mail.MailSendClient;
 import sample.cafekiosk.spring.domain.history.MailSendHistory;
 import sample.cafekiosk.spring.domain.history.MailSendHistoryRepository;
 import sample.cafekiosk.spring.domain.product.Product;
@@ -16,8 +19,11 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
 
 @SpringBootTest
+@Transactional
 class OrderStatisticsServiceTest {
     @Autowired
     private OrderStatisticsService orderStatisticsService;
@@ -29,6 +35,8 @@ class OrderStatisticsServiceTest {
     private ProductRepository productRepository;
     @Autowired
     private MailSendHistoryRepository mailSendHistoryRepository;
+    @MockBean
+    private MailSendClient mailSendClient;  // 행동 정의를 해줘야함.
 
     @DisplayName("결제완료된 주문들을 조회하여 매출 통계 매일을 전송한다.")
     @Test
@@ -46,6 +54,10 @@ class OrderStatisticsServiceTest {
         Order order2 = createPaymentCompletedOrder(products, now);
         Order order3 = createPaymentCompletedOrder(products, LocalDateTime.of(2024,4,1,23,59, 59));
         Order order4 = createPaymentCompletedOrder(products, LocalDateTime.of(2024,4,2,0,0, 0));
+
+        // Stubbing (Mock 객체의 행의 정의)
+        when(mailSendClient.sendEmail(any(String.class), any(String.class), any(String.class), any(String.class)))
+                .thenReturn(true);
         // when
         boolean result = orderStatisticsService.sendOrderStatisticsMail(now.toLocalDate(), "test@test.com");
 


### PR DESCRIPTION
#### 트랜잭션은 필요한 곳에만 적용하자.

- 네트워크를 타거나 실제로는 트랜잭션에 참여하지 않아도 되면서 오랜 시간이 소요되는 서비스 (ex. 메일 전송)에서는 트랜잭션을 소유하고 있지 않도록 `@Transactional`을 걸지 않는 것이 좋음.
 * `sendOrderStatisticsMail` 메서드 내에 find 메서드는 Repository 단에서 트랜잭션을 걸고 있음.
