### PR TITLE
Test Fixture 클렌징 작업

### DIFF
--- a/cafekiosk/src/main/java/sample/cafekiosk/spring/domain/order/Order.java
+++ b/cafekiosk/src/main/java/sample/cafekiosk/spring/domain/order/Order.java
@@ -8,7 +8,6 @@ import sample.cafekiosk.spring.domain.product.Product;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
@@ -25,6 +24,7 @@ public class Order extends BaseEntity {
 
     private LocalDateTime orderedDateTime;
 
+    // 다대다 연관관계를 풀어주는 중간 매핑.
     // mappedBy : OrderProduct 내 필드명으로 지정하여 매핑.
     @OneToMany(mappedBy = "order", orphanRemoval = true, cascade = CascadeType.ALL)
     private List<OrderProduct> orderProducts;
@@ -36,7 +36,7 @@ public class Order extends BaseEntity {
         this.orderedDateTime = orderedDateTime;
         this.orderProducts = products.stream()
                 .map(product -> new OrderProduct(this, product))
-                .collect(Collectors.toList());
+                .toList();
     }
 
     public static Order from(List<Product> products, LocalDateTime registeredDateTime) {

--- a/cafekiosk/src/main/java/sample/cafekiosk/spring/domain/orderproduct/OrderProduct.java
+++ b/cafekiosk/src/main/java/sample/cafekiosk/spring/domain/orderproduct/OrderProduct.java
@@ -8,6 +8,7 @@ import sample.cafekiosk.spring.domain.product.Product;
 
 /**
  * 일대다 다대일 관계 풀어주는 중간테이블 역할의 Entity.
+ * 여기서 Order, Product FK를 갖고있음.
  */
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/cafekiosk/src/main/java/sample/cafekiosk/spring/domain/orderproduct/OrderProductRepository.java
+++ b/cafekiosk/src/main/java/sample/cafekiosk/spring/domain/orderproduct/OrderProductRepository.java
@@ -1,0 +1,8 @@
+package sample.cafekiosk.spring.domain.orderproduct;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface OrderProductRepository extends JpaRepository<OrderProduct, Long> {
+}

--- a/cafekiosk/src/main/java/sample/cafekiosk/spring/domain/product/Product.java
+++ b/cafekiosk/src/main/java/sample/cafekiosk/spring/domain/product/Product.java
@@ -9,7 +9,7 @@ import sample.cafekiosk.spring.domain.BaseEntity;
 
 /**
  * 상품 테이블 Entity.
- * - 어떤 Order에 담겨있는지 알 필요 없음. -> ProductOrder 필드 갖고있을 필요 없음.
+ * - Product는 본인이 어떤 Order에 담겨있는지 알 필요 없음. -> ProductOrder 필드 갖고있지 않아도 됨.
  */
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/cafekiosk/src/main/resources/application.yml
+++ b/cafekiosk/src/main/resources/application.yml
@@ -1,0 +1,55 @@
+spring:
+  profiles:
+    active: local
+
+  datasource:
+    url: jdbc:h2:tcp://localhost/~/h2/bin/cafeKioskApplication;
+#    url: jdbc:h2:mem:~/cafeKioskApplication
+    driver-class-name: org.h2.Driver
+    username: sa
+    password: 1234
+
+  jpa:
+    hibernate:
+      ddl-auto: update
+
+---
+spring:
+  config:
+    activate:
+      on-profile: local
+
+  jpa:
+    hibernate:
+      ddl-auto: create
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+    defer-datasource-initialization: false
+
+  h2:
+    console:
+      enabled: true
+
+---
+spring:
+  config:
+    activate:
+      on-profile: test
+  jpa:
+    hibernate:
+      ddl-auto: create
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+    database-platform: org.hibernate.dialect.H2Dialect
+    defer-datasource-initialization: false
+  h2:
+    console:
+      enabled: true
+
+  sql:
+    init:
+      mode: never

--- a/cafekiosk/src/main/resources/data.sql
+++ b/cafekiosk/src/main/resources/data.sql
@@ -1,4 +1,0 @@
-insert into product(product_number, type, selling_status, name, price)
-    values('001', 'HANDMADE', 'SELLING', '아메리카노', 4000),
-          ('002', 'HANDMADE', 'HOLD', '라떼', 4500),
-          ('003', 'BAKERY', 'STOP_SELLING', '크로아상', 3500);

--- a/cafekiosk/src/test/java/sample/cafekiosk/spring/api/service/order/OrderServiceTest.java
+++ b/cafekiosk/src/test/java/sample/cafekiosk/spring/api/service/order/OrderServiceTest.java
@@ -1,5 +1,6 @@
 package sample.cafekiosk.spring.api.service.order;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -8,6 +9,8 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 import sample.cafekiosk.spring.api.service.order.dto.OrderCreateResponse;
 import sample.cafekiosk.spring.api.service.order.dto.OrderCreateServiceRequest;
+import sample.cafekiosk.spring.domain.order.OrderRepository;
+import sample.cafekiosk.spring.domain.orderproduct.OrderProductRepository;
 import sample.cafekiosk.spring.domain.product.Product;
 import sample.cafekiosk.spring.domain.product.ProductRepository;
 import sample.cafekiosk.spring.domain.product.ProductSellingStatus;
@@ -22,15 +25,29 @@ import static org.assertj.core.api.Assertions.*;
 
 @ActiveProfiles("test")
 @SpringBootTest
-@Transactional    // TODO 이슈 있음.
+//@Transactional    // TODO 이슈 있음.
 //@DataJpaTest  // JPA 관련 빈들만 조회하여 Service 클래스를 조회하지 못함.
 class OrderServiceTest {
     @Autowired
     private OrderService orderService;
     @Autowired
+    private OrderRepository orderRepository;
+    @Autowired
     private ProductRepository productRepository;
     @Autowired
     private StockRepository stockRepository;
+    @Autowired
+    private OrderProductRepository orderProductRepository;
+    @AfterEach
+    void tearDown() {
+        // 엔티티 간 연관관계로 인해 Side Effect 발생 가능함.
+        // product를 먼저 지우려 하면 orderProduct에서 참조하고 있으므로 이슈 발생. orderProduct를 먼저 지워줘야 함.
+        orderProductRepository.deleteAllInBatch();
+        orderRepository.deleteAllInBatch();
+        productRepository.deleteAllInBatch();
+
+        stockRepository.deleteAllInBatch();
+    }
     @Test
     @DisplayName("주문번호 리스트를 받아 주문을 생성한다.")
     void createOrder() {

--- a/cafekiosk/src/test/java/sample/cafekiosk/spring/api/service/product/ProductServiceTest.java
+++ b/cafekiosk/src/test/java/sample/cafekiosk/spring/api/service/product/ProductServiceTest.java
@@ -36,6 +36,7 @@ class ProductServiceTest {
         String targetProductNumber = "002";
         Product givenProduct = createProduct("001", HANDMADE, SELLING, "바닐라 라떼", 5000);
         productRepository.save(givenProduct);
+        productRepository.flush();
 
         ProductCreateServiceRequest request = new ProductCreateServiceRequest(HANDMADE, SELLING, "와플", 7000);
         // when

--- a/cafekiosk/src/test/java/sample/cafekiosk/spring/domain/product/ProductRepositoryTest.java
+++ b/cafekiosk/src/test/java/sample/cafekiosk/spring/domain/product/ProductRepositoryTest.java
@@ -1,10 +1,13 @@
 package sample.cafekiosk.spring.domain.product;
 
+import com.querydsl.jpa.impl.JPAQueryFactory;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
+import sample.cafekiosk.spring.config.JpaConfig;
 
 import java.util.List;
 
@@ -15,9 +18,11 @@ import static sample.cafekiosk.spring.domain.product.ProductSellingStatus.SELLIN
 
 //@SpringBootTest
 @DataJpaTest        // @Transactional이 붙어있는 애노테이션
+@Import(JpaConfig.class)
 @ActiveProfiles("test")
 class ProductRepositoryTest {
-
+    @Autowired
+    JPAQueryFactory jpaQueryFactory;
     @Autowired
     ProductRepository productRepository;
     @DisplayName("원하는 판매 상품 상태를 가진 제품을 전체 조회한다.")
@@ -28,6 +33,7 @@ class ProductRepositoryTest {
 
         Product stopSellingLatte = createProduct("001", ProductType.HANDMADE, STOP_SELLING, "카페 라떼", 5000);
         productRepository.saveAll(List.of(sellingBakery, stopSellingLatte));
+
         // when
         List<Product> results = productRepository.findAllBySellingStatusIn(List.of(SELLING, STOP_SELLING));
 
@@ -74,6 +80,7 @@ class ProductRepositoryTest {
         Product stopSellingLatte = createProduct("002", ProductType.HANDMADE, STOP_SELLING, "카페 라떼", 5000);
         Product holdShavedIce = createProduct(targetProductNumber, ProductType.HANDMADE, HOLD, "팥빙수", 7000);
         productRepository.saveAll(List.of(sellingBakery, stopSellingLatte, holdShavedIce));
+        productRepository.flush();
 
         // when
         String latestProductNumber = productRepository.findLatestProductNumberOrderByIdDesc();

--- a/cafekiosk/src/test/java/sample/cafekiosk/spring/domain/stock/StockRepositoryTest.java
+++ b/cafekiosk/src/test/java/sample/cafekiosk/spring/domain/stock/StockRepositoryTest.java
@@ -1,18 +1,26 @@
 package sample.cafekiosk.spring.domain.stock;
 
+import com.querydsl.jpa.impl.JPAQueryFactory;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
+import sample.cafekiosk.spring.config.JpaConfig;
 
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.groups.Tuple.tuple;
+
 @DataJpaTest
+@Import(JpaConfig.class)
 @ActiveProfiles("test")
 class StockRepositoryTest {
+
+    @Autowired
+    JPAQueryFactory jpaQueryFactory;
     @Autowired
     private StockRepository stockRepository;
 


### PR DESCRIPTION
## Test Fixture 클렌징
> `@Transactional`, `deleteAll()`, `deleteAllInBatch()`

`@Transactional` 롤백 방식이 가장 편리하나, 이를 사용하기 힘든 경우가 있음. 트랜잭션이 여러 개 걸리는 서비스를 테스트할 때! 수동으로 클렌징해야 함. 


> 연관관계 참고사항
Product - OrderProduct - Order 엔티티가 존재.
OrderProduct가 Product와 Order 엔티티의 다대다 관계를 풀어주는 매핑 테이블

Product 입장에서는 본인이 주문(Order)에 속해있는지 알 필요가 없으므로 Product에는 주문(Order)이나 OrderProduct 정보를 갖고 있지 않아도 됨.
그래서 OrderProduct와 Order 간에만 다대일 연관관계가 매핑되어 있음.


### `deleteAll`과 `deleteAllInBatch`
`deleteAll`
- 삭제하기 전에 전체 데이터 조회 쿼리문을 수행하고, 데이터 갯수만큼 1건씩 delete문을 수행함.
- 만약 orderProduct와 order 처럼 연관관계가 있다면, 
  - orderProduct 전체 조회 후 데이터 갯수만큼 orderProduct delete문 수행
  - product 전체 조회 후 데이터 갯수만큼 product delete문 수행
  - order 전체 조회  -> 특정 order ID에 연관관계 맺고 있는 orderProduct 조회하여 있으면 delete문 수행. -> order delete문 수행

장점 : 위와 같이 연관관계를 맺고 있다면, 자동으로 제거해주는 것은 편리함. 
단점 :
- 테스트 비용적인 측면에서 다수의 쿼리로 인해 작업 속도가 느림. 
- 관계를 고려하여 삭제해야 함. ex) orderProduct보다 product를 먼저 지우면 FK 참조 이슈 발생. 

`deleteAllInBatch`
- 벌크 성 delete 쿼리문 수행.

장점 : 적은 쿼리 수로, 빠른 속도로 클렌징 가능.
단점 : 관계를 고려하여 삭제해야 함.
