### PR TITLE
feat : @ParameterizedTest를 이용해 하나의 테스트 메서드에서 여러 소스를 전달하여 테스트할 수 있다.

### DIFF
--- a/cafekiosk/src/test/java/sample/cafekiosk/spring/domain/product/ProductRepositoryTest.java
+++ b/cafekiosk/src/test/java/sample/cafekiosk/spring/domain/product/ProductRepositoryTest.java
@@ -31,7 +31,7 @@ class ProductRepositoryTest {
         // given
         Product sellingBakery = createProduct("001", ProductType.BAKERY, SELLING, "소금빵", 3500);
 
-        Product stopSellingLatte = createProduct("001", ProductType.HANDMADE, STOP_SELLING, "카페 라떼", 5000);
+        Product stopSellingLatte = createProduct("002", ProductType.HANDMADE, STOP_SELLING, "카페 라떼", 5000);
         productRepository.saveAll(List.of(sellingBakery, stopSellingLatte));
 
         // when
@@ -42,7 +42,7 @@ class ProductRepositoryTest {
         assertThat(results).extracting("productNumber", "name", "sellingStatus")
                 .containsExactlyInAnyOrder(
                         tuple("001", "소금빵", SELLING),
-                        tuple("001", "카페 라떼", STOP_SELLING)
+                        tuple("002", "카페 라떼", STOP_SELLING)
                 );
 
     }

--- a/cafekiosk/src/test/java/sample/cafekiosk/spring/domain/product/ProductTypeTest.java
+++ b/cafekiosk/src/test/java/sample/cafekiosk/spring/domain/product/ProductTypeTest.java
@@ -2,6 +2,12 @@ package sample.cafekiosk.spring.domain.product;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -30,4 +36,35 @@ class ProductTypeTest {
         // then
         assertThat(result).isFalse();
     }
+
+    private static Stream<Arguments> provideProductTypesRelatedStock() {
+        return Stream.of(
+                Arguments.of(ProductType.BAKERY, true),
+                Arguments.of(ProductType.BOTTLE, true),
+                Arguments.of(ProductType.HANDMADE, false)
+        );
+    }
+
+    // 하나의 메서드에서 여러 소스를 전달하여 모든 케이스를 테스트할 수 있다.
+    @DisplayName("상품 타입이 재고 관리 상품 타입인지를 체크한다.")
+    @MethodSource("provideProductTypesRelatedStock")
+    @ParameterizedTest(name = "{index}. ''{0}'' => {1}")
+    void containsStockType_TrueFalse_methodSource(ProductType productType, boolean expected) {
+        // when
+        boolean result = ProductType.containsStockType(productType);
+        // then
+        assertThat(result).isEqualTo(expected);
+    }
+
+    @DisplayName("상품 타입이 재고 관리 상품 타입인지를 체크한다.")
+    @CsvSource({"BAKERY,true", "BOTTLE,true", "HANDMADE,false"})
+    @ParameterizedTest(name = "{index}. ''{0}'' => {1}")
+    void containsStockType_TrueFalse_csvSource(ProductType productType, boolean expected) {
+        // when
+        boolean result = ProductType.containsStockType(productType);
+        // then
+        assertThat(result).isEqualTo(expected);
+    }
+
+
 }


### PR DESCRIPTION
### `@ParameterizedTest`

하나의 케이스에서 여러 개의 값/환경 데이터를 바꿔가며 테스트하고 싶을 때 사용하기 유용한 JUnit 애노테이션.

Ex) ProductType Enum 클래스 중 재고 관리 타입이면 True이고 아니면 False를 반환하는 테스트를 모든 타입에 대해 테스트해보고 싶을 때.
[AS-IS] 동일한 상황을 테스트하는 것이지만 True와 False를 나누어 작성하였다.
[TO-BE] @ParameterizedTest 애노테이션을 이용해  파라미터에 n개의 소스 전달.


소스를 전달하는 애노테이션
- `@CsvSource`  : 콤마 구분자로 파라미터에 전달하는 방식.
- `@MethodSource` : 하나의 메서드에서 테스트할 파라미터를 전달하는 방식. 메서드 이름으로 구분한다. 테스트할 source가 너무 많은 경우 좋은 방법.
그외에도 `@ValueSource`, `@NullSource`, `@EmptySource`, `@NullAndEmptySource`, `@EnumSource` 등 존재함.


> 참고) 여러 데이터에 대해 테스트를 진행하므로 어떤 값이 어떤 결과를 주는지 name 옵션을 통해 알려줄 수 있다. 
`@ParameterizedTest(name = "{index}. ''{0}'' => {1}")`
ㄴ 결과 : `1. 'BAKERY' => true`
