### PR TITLE
feat : private 메서드였던 createNextProductNumber를 ProductService 클래스와 분리한다.

### DIFF
--- a/cafekiosk/src/main/java/sample/cafekiosk/spring/api/service/product/ProductNumberFactory.java
+++ b/cafekiosk/src/main/java/sample/cafekiosk/spring/api/service/product/ProductNumberFactory.java
@@ -1,0 +1,28 @@
+package sample.cafekiosk.spring.api.service.product;
+
+import io.micrometer.common.util.StringUtils;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import sample.cafekiosk.spring.domain.product.ProductRepository;
+
+/**
+ * 상품 번호를 순차적으로 생성하는 팩토리 클래스.
+ */
+@RequiredArgsConstructor
+@Component
+public class ProductNumberFactory {
+    private final ProductRepository productRepository;
+
+    public String createNextProductNumber() {
+        // 가장 최근의 productNumber 조회
+        String productNumber = productRepository.findLatestProductNumberOrderByIdDesc();
+        String initProductNumber = "001";
+        if (StringUtils.isEmpty(productNumber)) {
+            return initProductNumber;
+        }
+        Integer nextProductNumberInt = Integer.parseInt(productNumber) + 1;
+
+        return String.format("%03d", nextProductNumberInt);
+    }
+
+}

--- a/cafekiosk/src/main/java/sample/cafekiosk/spring/api/service/product/ProductService.java
+++ b/cafekiosk/src/main/java/sample/cafekiosk/spring/api/service/product/ProductService.java
@@ -1,6 +1,5 @@
 package sample.cafekiosk.spring.api.service.product;
 
-import io.micrometer.common.util.StringUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,25 +16,15 @@ import java.util.List;
 @Service
 public class ProductService {
     private final ProductRepository productRepository;
+    private final ProductNumberFactory productNumberFactory;
 
     @Transactional
     public ProductResponse createProduct(ProductCreateServiceRequest request) {
-        String nextProductNumber = createNextProductNumber();
+        String nextProductNumber = productNumberFactory.createNextProductNumber();
 
         Product product = request.toEntity(nextProductNumber);
         Product savedProduct = productRepository.save(product);
         return ProductResponse.of(savedProduct);
-    }
-    private String createNextProductNumber() {
-        // 가장 최근의 productNumber 조회
-        String productNumber = productRepository.findLatestProductNumberOrderByIdDesc();
-        String initProductNumber = "001";
-        if (StringUtils.isEmpty(productNumber)) {
-            return initProductNumber;
-        }
-        Integer nextProductNumberInt = Integer.parseInt(productNumber) + 1;
-
-        return String.format("%03d", nextProductNumberInt);
     }
 
     public List<ProductResponse> getSellingProducts() {

--- a/cafekiosk/src/test/java/sample/cafekiosk/spring/api/service/product/ProductNumberFactoryTest.java
+++ b/cafekiosk/src/test/java/sample/cafekiosk/spring/api/service/product/ProductNumberFactoryTest.java
@@ -1,0 +1,66 @@
+package sample.cafekiosk.spring.api.service.product;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import sample.cafekiosk.spring.IntigrationTestSupport;
+import sample.cafekiosk.spring.domain.product.Product;
+import sample.cafekiosk.spring.domain.product.ProductRepository;
+import sample.cafekiosk.spring.domain.product.ProductSellingStatus;
+import sample.cafekiosk.spring.domain.product.ProductType;
+
+import java.util.Collection;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ProductNumberFactoryTest extends IntigrationTestSupport {
+    @Autowired
+    private ProductNumberFactory productNumberFactory;
+
+    @Autowired
+    private ProductRepository productRepository;
+
+    @DisplayName("다음 상품 번호를 생성한다.")
+    @Test
+    void createNextProductNumber() {
+        // given
+        String firstProductNumber = "001";
+        // when
+        String result = productNumberFactory.createNextProductNumber();
+        // then
+        assertThat(result).isEqualTo(firstProductNumber);
+    }
+
+    @DisplayName("순차적으로 다음 상품 번호를 생성한다.")
+    @TestFactory
+    Collection<DynamicTest> dynamicCreateProductNumber() {
+        // given
+        String firstProductNumber = "001";
+
+        return List.of(
+                DynamicTest.dynamicTest("첫번째 생성되는 상품 번호는 001이다.", () -> {
+                    // given
+                    String result = productNumberFactory.createNextProductNumber();
+                    // then
+                    assertThat(result).isEqualTo(firstProductNumber);
+                }),
+                DynamicTest.dynamicTest("상품번호는 001씩 증가한다.", () -> {
+                    // given
+                    Product firstProduct = Product.builder()
+                            .name("")
+                            .sellingStatus(ProductSellingStatus.SELLING)
+                            .productNumber(firstProductNumber)
+                            .type(ProductType.HANDMADE)
+                            .build();
+                    productRepository.saveAndFlush(firstProduct);
+                    String secondProductNumber = "002";
+                    // when
+                    String result = productNumberFactory.createNextProductNumber();
+                    // then
+                    assertThat(result).isEqualTo(secondProductNumber);
+                }));
+    }
+}


### PR DESCRIPTION
### Private 메서드 테스트
> 기본 원칙.
객체가 공개한 API에 대해서만 테스트해도 괜찮다.
private 메서드는 private 메서드의 의도에 따라 테스트할 필요도 없고, 테스트하려고도 하면 안된다.

그럼에도 단독으로 분리해서 테스트를 하고 싶은 욕구가 들 정도라면,
'객체를 분리해야 할 시점인가'를 고민해보자.

상품 생성 메서드를 테스트하면서 상품번호 생성에 대한 테스트를 진행하는게 맞는지 모르겠다?
-> 상품 생성과 상품번호 생성을 분리한다.
Ex) `ProductNumberFactory` 클래스로 분리
