### PR TITLE
feat: RestDocs 라이브러리 및 ProductControllerDocsTest 추가

### DIFF
--- a/cafekiosk/build.gradle
+++ b/cafekiosk/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.2.2'
     id 'io.spring.dependency-management' version '1.1.4'
+    id 'org.asciidoctor.jvm.convert' version '4.0.2'
 }
 
 group = 'sample'
@@ -15,6 +16,7 @@ configurations {
     compileOnly {
         extendsFrom annotationProcessor
     }
+    asciidoctorExt
 }
 
 repositories {
@@ -38,10 +40,34 @@ dependencies {
     annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
     annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
     annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
+    // RestDocs
+    asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
+    testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
 }
 
 tasks.named('test') {
     useJUnitPlatform()
+}
+// 전역변수
+ext {
+    snippetsDir = file('build/generated-snippets')
+}
+// test task 실행 시 snippetsDir 생성
+test {
+    outputs.dir snippetsDir
+}
+// asciidoctor task 실행 시 snippetsDir, asciidoctorExt 참조
+asciidoctor {
+    inputs.dir snippetsDir
+    configurations 'asciidoctorExt'
+    dependsOn test
+}
+// bootJar task 실행 시 output을 static/docs로 이동
+bootJar {
+    dependsOn asciidoctor
+    from("${asciidoctor.outputDir}") {
+        into 'static/docs'
+    }
 }
 
 // Querydsl 추가, 자동 생성된 Q클래스 gradle clean으로 제거

--- a/cafekiosk/src/docs/asciidoc/index.adoc
+++ b/cafekiosk/src/docs/asciidoc/index.adoc
@@ -1,0 +1,23 @@
+ifndef::snippets[]
+:snippets: ../../build/generated-snippets
+endif::[]
+= CafeKiosk Rest API 문서
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 2
+:sectlinks:
+
+[[Product-API]]
+== Product API
+[[product-create]]
+=== 신규 상품 등록
+
+==== Http Request
+include::{snippets}/product-create/http-request.adoc[]
+include::{snippets}/product-create/request-fields.adoc[]
+
+==== Http Response
+include::{snippets}/product-create/http-response.adoc[]
+include::{snippets}/product-create/response-fields.adoc[]

--- a/cafekiosk/src/main/java/sample/cafekiosk/spring/api/service/product/dto/ProductResponse.java
+++ b/cafekiosk/src/main/java/sample/cafekiosk/spring/api/service/product/dto/ProductResponse.java
@@ -5,7 +5,6 @@ import sample.cafekiosk.spring.domain.product.Product;
 import sample.cafekiosk.spring.domain.product.ProductSellingStatus;
 import sample.cafekiosk.spring.domain.product.ProductType;
 @Getter
-@Builder(access = AccessLevel.PRIVATE)
 public class ProductResponse {
     private Long id;
 
@@ -18,6 +17,16 @@ public class ProductResponse {
     private String name;
 
     private int price;
+
+    @Builder
+    private ProductResponse(Long id, String productNumber, ProductType type, ProductSellingStatus sellingStatus, String name, int price) {
+        this.id = id;
+        this.productNumber = productNumber;
+        this.type = type;
+        this.sellingStatus = sellingStatus;
+        this.name = name;
+        this.price = price;
+    }
 
     public static ProductResponse of(Product product) {
         return ProductResponse.builder()

--- a/cafekiosk/src/test/java/sample/cafekiosk/spring/RestDocsSupport.java
+++ b/cafekiosk/src/test/java/sample/cafekiosk/spring/RestDocsSupport.java
@@ -1,0 +1,31 @@
+package sample.cafekiosk.spring;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+/**
+ * RestDocs 테스트의 환경 통합 지원하는 클래스
+ */
+@ExtendWith(RestDocumentationExtension.class)
+public abstract class RestDocsSupport {
+    protected MockMvc mockMvc;
+    protected ObjectMapper objectMapper = new ObjectMapper();
+
+    /**
+     * RestDocsSupport를 상속받는 컨트롤러들을 초기화하고, Docs Configuration을 설정하여 mockMvc를 커스텀 생성한다.
+     * @param provider RestDocs 환경 제공 Provider
+     */
+    @BeforeEach
+    void setUp(RestDocumentationContextProvider provider) {
+        this.mockMvc = MockMvcBuilders.standaloneSetup(initController())       // 스프링에서 만들어주는 MockMvc를 주입해줬지만, 이번에는 직접 생성한다.
+                .apply(MockMvcRestDocumentation.documentationConfiguration(provider))   // 문서를 만들기 위한 설정에 provider 제공
+                .build();
+    }
+
+    protected abstract Object initController();
+}

--- a/cafekiosk/src/test/java/sample/cafekiosk/spring/docs/ProductControllerDocsTest.java
+++ b/cafekiosk/src/test/java/sample/cafekiosk/spring/docs/ProductControllerDocsTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation;
+import org.springframework.restdocs.operation.preprocess.Preprocessors;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.restdocs.payload.PayloadDocumentation;
 import sample.cafekiosk.spring.RestDocsSupport;
@@ -51,6 +52,8 @@ class ProductControllerDocsTest extends RestDocsSupport {
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andDo(MockMvcRestDocumentation.document("product-create",
+                    Preprocessors.preprocessRequest(Preprocessors.prettyPrint()),
+                    Preprocessors.preprocessResponse(Preprocessors.prettyPrint()),
                     PayloadDocumentation.requestFields(
                         PayloadDocumentation.fieldWithPath("type").type(JsonFieldType.STRING)   // Enum은 String으로.
                             .description("상품 타입"),

--- a/cafekiosk/src/test/java/sample/cafekiosk/spring/docs/ProductControllerDocsTest.java
+++ b/cafekiosk/src/test/java/sample/cafekiosk/spring/docs/ProductControllerDocsTest.java
@@ -1,0 +1,88 @@
+package sample.cafekiosk.spring.docs;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.restdocs.payload.PayloadDocumentation;
+import sample.cafekiosk.spring.RestDocsSupport;
+import sample.cafekiosk.spring.api.controller.product.ProductController;
+import sample.cafekiosk.spring.api.service.product.ProductService;
+import sample.cafekiosk.spring.api.service.product.dto.ProductCreateRequest;
+import sample.cafekiosk.spring.api.service.product.dto.ProductCreateServiceRequest;
+import sample.cafekiosk.spring.api.service.product.dto.ProductResponse;
+import sample.cafekiosk.spring.domain.product.ProductSellingStatus;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static sample.cafekiosk.spring.domain.product.ProductType.HANDMADE;
+
+class ProductControllerDocsTest extends RestDocsSupport {
+    private final ProductService productService = Mockito.mock(ProductService.class);
+    @Override
+    protected Object initController() {
+        return new ProductController(productService);
+    }
+
+    @DisplayName("신규 상품을 등록하는 API")
+    @Test
+    void createProduct() throws Exception {
+        ProductCreateRequest request = new ProductCreateRequest(HANDMADE, ProductSellingStatus.SELLING, "아메리카노", 4000);
+        given(productService.createProduct(any(ProductCreateServiceRequest.class)))
+                .willReturn(ProductResponse.builder()
+                        .id(1L)
+                        .productNumber("001")
+                        .sellingStatus(ProductSellingStatus.SELLING)
+                        .name("아메리카노")
+                        .price(4000)
+                        .type(HANDMADE)
+                        .build()
+                );
+        mockMvc.perform(
+                post("/api/v1/products/new")
+                    .content(objectMapper.writeValueAsString(request))  //  직렬화 위해 ObjectMapper 이용.contentType(MediaType.APPLICATION_JSON)
+                        .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andDo(MockMvcRestDocumentation.document("product-create",
+                    PayloadDocumentation.requestFields(
+                        PayloadDocumentation.fieldWithPath("type").type(JsonFieldType.STRING)   // Enum은 String으로.
+                            .description("상품 타입"),
+                        PayloadDocumentation.fieldWithPath("sellingStatus").type(JsonFieldType.STRING)
+                            .description("상품 판매상태"),
+                        PayloadDocumentation.fieldWithPath("name").type(JsonFieldType.STRING)
+                            .description("상품 이름"),
+                        PayloadDocumentation.fieldWithPath("price").type(JsonFieldType.NUMBER)
+                            .description("상품 가격")
+                    ),
+                    PayloadDocumentation.responseFields(
+                        PayloadDocumentation.fieldWithPath("code").type(JsonFieldType.NUMBER)
+                            .description("응답 코드"),
+                        PayloadDocumentation.fieldWithPath("status").type(JsonFieldType.STRING)
+                            .description("응답 상태"),
+                        PayloadDocumentation.fieldWithPath("message").type(JsonFieldType.STRING)
+                            .description("응답 메시지"),
+                        PayloadDocumentation.fieldWithPath("data").type(JsonFieldType.OBJECT)
+                            .description("응답 데이터"),
+                        PayloadDocumentation.fieldWithPath("data.id").type(JsonFieldType.NUMBER)
+                            .description("상품 ID"),
+                        PayloadDocumentation.fieldWithPath("data.productNumber").type(JsonFieldType.STRING)
+                            .description("상품 번호"),
+                        PayloadDocumentation.fieldWithPath("data.type").type(JsonFieldType.STRING)
+                            .description("상품 상태"),
+                        PayloadDocumentation.fieldWithPath("data.sellingStatus").type(JsonFieldType.STRING)
+                            .description("상품 판매상태"),
+                        PayloadDocumentation.fieldWithPath("data.name").type(JsonFieldType.STRING)
+                            .description("상품 이름"),
+                        PayloadDocumentation.fieldWithPath("data.price").type(JsonFieldType.NUMBER)
+                            .description("상품 가격")
+                    )
+                ));
+    }
+}


### PR DESCRIPTION
### 1) RestDocs 환경 구성 클래스 작성
문서를 만들 때 Spring Boot 서버를 사용하게 되면 아래와 같이 작성하면 되겠으나,
문서를 만들 때 굳이 서버를 띄울 필요가 없다고 본다면 아래와 같이 RestDocs를 위한 환경을 구성한다.
```java
@ExtendWith(RestDocumentationExtension.class)
@SpringBootTest
public abstract class RestDocsSupport {
    protected MockMvc mockMvc;

    @BeforeEach
    void setUp(WebApplicationContext webApplicationContext, RestDocumentationContextProvider provider) {
        this.mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext)
                .apply(MockMvcRestDocumentation.documentationConfiguration(provider))
                .build();
    }
}
```

### 2) 컨트롤러 클래스 테스트코드 작성
컨트롤러 테스트 1개 작성 후 gradle > Tasks > documentation > asciidoctor 실행해보면, 
테스트가 수행된 후에 문서 조각들이 지정한 경로(`build/generated-snippets`)에 생성됨. 

- 디렉토리 명 : 컨트롤러 테스트에서 `MockMvcRestDocumentation.document()` 에 지정한 Identifier 명.
- adoc 의미 : ascii doc 파일
- 코드 조각들을 하나로 합쳐서 루트가 될 문서를 작성해야 한다.

---

### 커밋
- ProductControllerDocsTest 추가
- RestDocs 테스트 환경 구성 위한 Support 클래스 추가
