### PR TITLE
feat: RestDocs fields 커스텀 + adoc 파일 분리

### DIFF
--- a/cafekiosk/build.gradle
+++ b/cafekiosk/build.gradle
@@ -60,6 +60,11 @@ test {
 asciidoctor {
     inputs.dir snippetsDir
     configurations 'asciidoctorExt'
+
+    sources {  //  다른 adoc들은 include로 포함되도록 하고 index.adoc으로 HTML 생성
+        include("**/index.adoc")
+    }
+    baseDirFollowsSourceFile() // 다른 adoc 파일 include 시 경로를 baseDir에 맞춘다.
     dependsOn test
 }
 // bootJar task 실행 시 output을 static/docs로 이동

--- a/cafekiosk/src/docs/asciidoc/domain/product/product.adoc
+++ b/cafekiosk/src/docs/asciidoc/domain/product/product.adoc
@@ -1,0 +1,10 @@
+[[product-create]]
+=== 신규 상품 등록
+
+==== Http Request
+include::{snippets}/product-create/http-request.adoc[]
+include::{snippets}/product-create/request-fields.adoc[]
+
+==== Http Response
+include::{snippets}/product-create/http-response.adoc[]
+include::{snippets}/product-create/response-fields.adoc[]

--- a/cafekiosk/src/docs/asciidoc/index.adoc
+++ b/cafekiosk/src/docs/asciidoc/index.adoc
@@ -11,13 +11,5 @@ endif::[]
 
 [[Product-API]]
 == Product API
-[[product-create]]
-=== 신규 상품 등록
 
-==== Http Request
-include::{snippets}/product-create/http-request.adoc[]
-include::{snippets}/product-create/request-fields.adoc[]
-
-==== Http Response
-include::{snippets}/product-create/http-response.adoc[]
-include::{snippets}/product-create/response-fields.adoc[]
+include::domain/product/product.adoc[]

--- a/cafekiosk/src/test/java/sample/cafekiosk/spring/docs/ProductControllerDocsTest.java
+++ b/cafekiosk/src/test/java/sample/cafekiosk/spring/docs/ProductControllerDocsTest.java
@@ -58,6 +58,7 @@ class ProductControllerDocsTest extends RestDocsSupport {
                         PayloadDocumentation.fieldWithPath("type").type(JsonFieldType.STRING)   // Enum은 String으로.
                             .description("상품 타입"),
                         PayloadDocumentation.fieldWithPath("sellingStatus").type(JsonFieldType.STRING)
+                            .optional()
                             .description("상품 판매상태"),
                         PayloadDocumentation.fieldWithPath("name").type(JsonFieldType.STRING)
                             .description("상품 이름"),

--- a/cafekiosk/src/test/resources/org/springframework/restdocs/templates/request-fields.snippet
+++ b/cafekiosk/src/test/resources/org/springframework/restdocs/templates/request-fields.snippet
@@ -1,0 +1,15 @@
+==== Request Fields
+|===
+
+|Path|Type|Optional|Description
+
+{{#fields}}
+
+|{{#tableCellContent}}`+{{path}}+`{{/tableCellContent}}
+|{{#tableCellContent}}`+{{type}}+`{{/tableCellContent}}
+|{{#tableCellContent}}{{#optional}}O{{/optional}}{{/tableCellContent}}
+|{{#tableCellContent}}{{description}}{{/tableCellContent}}
+
+{{/fields}}
+
+|===

--- a/cafekiosk/src/test/resources/org/springframework/restdocs/templates/response-fields.snippet
+++ b/cafekiosk/src/test/resources/org/springframework/restdocs/templates/response-fields.snippet
@@ -1,0 +1,15 @@
+==== Response Fields
+|===
+
+|Path|Type|Optional|Description
+
+{{#fields}}
+
+|{{#tableCellContent}}`+{{path}}+`{{/tableCellContent}}
+|{{#tableCellContent}}`+{{type}}+`{{/tableCellContent}}
+|{{#tableCellContent}}{{#optional}}O{{/optional}}{{/tableCellContent}}
+|{{#tableCellContent}}{{description}}{{/tableCellContent}}
+
+{{/fields}}
+
+|===


### PR DESCRIPTION
### 커스텀한 request/response 필드 추가 
optional과 같은 필드의 특성을 추가하려면, Snippet을 커스텀해야함.

### `index.adoc` 에서 각 API 별 adoc 파일 추출
도메인 혹은 API 별 adoc 파일을 분리하고, 이를 하나의 `index.html` 파일로 생성되도록 설정한다.
```gradle
// asciidoctor task 실행 시 snippetsDir, asciidoctorExt 참조
asciidoctor {
    inputs.dir snippetsDir
    configurations 'asciidoctorExt'

    sources {  //  다른 adoc들은 include로 포함되도록 하고 index.adoc으로 HTML 생성
        include("**/index.adoc")
    }
    baseDirFollowsSourceFile() // 다른 adoc 파일 include 시 경로를 baseDir에 맞춘다.
    dependsOn test
}
```

<지식공유자님의 작업 방식>
Mock 이용하여 Docs Test를 먼저 작성 (가능하면 bean validation) -> 배포 -> 관계인들에게 문서 공유 -> 서비스단 기능 개발

---

#### 커밋
- index.html 파일 1개로 생성되도록 세팅
- feat: 필드 옵션 커스텀 (optional)
- adoc 파일 및 snippet 추가
- index.adoc 파일 분리